### PR TITLE
V3.5a

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:latest as build-stage
-ENV  DEBIAN_FRONTEND noninteractive
+
+ARG TMUX_VERSION=3.5
+ENV TMUX_VERSION=${TMUX_VERSION}
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt update && apt install -y \
 	automake \
 	bison \
@@ -9,9 +12,10 @@ RUN apt update && apt install -y \
 	pkg-config \
 	wget
 
-RUN wget -O- https://github.com/tmux/tmux/archive/3.5.tar.gz  | tar -xzvf -
-WORKDIR tmux-3.5
+RUN wget -O- https://github.com/tmux/tmux/archive/${TMUX_VERSION}.tar.gz  | tar -xzvf -
+WORKDIR tmux-${TMUX_VERSION}
 RUN ./autogen.sh && ./configure --enable-static && make -j8
 
 FROM scratch as exporter
-COPY --from=build-stage /tmux-3.5/tmux /
+ARG TMUX_VERSION
+COPY --from=build-stage /tmux-${TMUX_VERSION}/tmux /

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest as build-stage
 
-ARG TMUX_VERSION=3.5
+ARG TMUX_VERSION=3.5a
 ENV TMUX_VERSION=${TMUX_VERSION}
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt update && apt install -y \

--- a/Containerfile
+++ b/Containerfile
@@ -12,10 +12,10 @@ RUN apt update && apt install -y \
 	pkg-config \
 	wget
 
-RUN wget -O- https://github.com/tmux/tmux/archive/${TMUX_VERSION}.tar.gz  | tar -xzvf -
-WORKDIR tmux-${TMUX_VERSION}
+RUN wget -O- https://github.com/tmux/tmux/archive/${TMUX_VERSION}.tar.gz  | tar -xzvf - && \
+    mv tmux-${TMUX_VERSION} /tmux
+WORKDIR tmux
 RUN ./autogen.sh && ./configure --enable-static && make -j8
 
 FROM scratch as exporter
-ARG TMUX_VERSION
-COPY --from=build-stage /tmux-${TMUX_VERSION}/tmux /
+COPY --from=build-stage /tmux/tmux /


### PR DESCRIPTION
This bumps the version to 3.5a.

Instead of changing the version all over the `CONTAINERFILE` I added an `ARG` in d8b9d184928d742f8d636836485ba3c25bcc8755. The actual version bump is in e61d36a357048512d21feaf7243a3d24bc843417.
